### PR TITLE
Fix async product loading for iOS 17 APIs

### DIFF
--- a/OnDemoAppApp.swift
+++ b/OnDemoAppApp.swift
@@ -23,3 +23,4 @@ struct OnDemoAppApp: App {
         }
     }
 }
+

--- a/Views/HomeView.swift
+++ b/Views/HomeView.swift
@@ -16,7 +16,9 @@ struct HomeView: View {
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
                 } else if let error = productService.error {
                     ErrorView(error: error) {
-                        productService.loadProducts()
+                        Task {
+                            await productService.loadProducts()
+                        }
                     }
                 } else if productService.products.isEmpty {
                     ContentUnavailableView(
@@ -38,7 +40,7 @@ struct HomeView: View {
             }
             .task {
                 if productService.products.isEmpty {
-                    productService.loadProducts()
+                    await productService.loadProducts()
                 }
             }
         }

--- a/Views/SearchView.swift
+++ b/Views/SearchView.swift
@@ -135,7 +135,7 @@ struct SearchView: View {
             }
             .task {
                 if productService.products.isEmpty {
-                    productService.loadProducts()
+                    await productService.loadProducts()
                 }
             }
         }


### PR DESCRIPTION
## Summary
- convert the product service to use async/await so loading and refresh hooks compile against modern SwiftUI
- update Home and Search views to await the async loaders and retry via Task closures
- tidy app entry point file endings

## Testing
- not run (not available in container)

------
https://chatgpt.com/codex/tasks/task_b_68e2df6201a8832d8cdf6148345a0d39