### PR TITLE
Fix badge and loading state build errors

### DIFF
--- a/ContentView.swift
+++ b/ContentView.swift
@@ -26,7 +26,7 @@ struct ContentView: View {
                     Image(systemName: "cart.fill")
                     Text("Cart")
                 }
-                .badge(cartManager.itemCount > 0 ? cartManager.itemCount : nil)
+                .optionalBadge(cartManager.itemCount)
 
             ProfileView()
                 .tabItem {
@@ -35,6 +35,20 @@ struct ContentView: View {
                 }
         }
         .tint(.blue)
+    }
+}
+
+private extension View {
+    /// Conditionally applies a badge modifier when the provided count is greater than zero.
+    /// - Parameter count: The badge value to display.
+    /// - Returns: Either the original view or the view with a badge applied.
+    @ViewBuilder
+    func optionalBadge(_ count: Int) -> some View {
+        if count > 0 {
+            self.badge(count)
+        } else {
+            self
+        }
     }
 }
 

--- a/Views/HomeView.swift
+++ b/Views/HomeView.swift
@@ -10,38 +10,36 @@ struct HomeView: View {
     
     var body: some View {
         NavigationStack {
-            Group {
-                if productService.isLoading {
-                    ProgressView("Loading products...")
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
-                } else if let error = productService.error {
-                    ErrorView(error: error) {
-                        Task {
-                            await productService.loadProducts()
-                        }
-                    }
-                } else if productService.products.isEmpty {
-                    ContentUnavailableView(
-                        "No Products",
-                        systemImage: "tray",
-                        description: Text("No products available at the moment.")
-                    )
-                } else {
-                    List(productService.products) { product in
-                        NavigationLink(destination: ProductDetailView(product: product)) {
-                            ProductRowView(product: product)
-                        }
+            if productService.isLoading {
+                ProgressView("Loading products...")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if let error = productService.error {
+                ErrorView(error: error) {
+                    Task {
+                        await productService.loadProducts()
                     }
                 }
-            }
-            .navigationTitle("On Store")
-            .refreshable {
-                await productService.refreshProducts()
-            }
-            .task {
-                if productService.products.isEmpty {
-                    await productService.loadProducts()
+            } else if productService.products.isEmpty {
+                ContentUnavailableView(
+                    "No Products",
+                    systemImage: "tray",
+                    description: Text("No products available at the moment.")
+                )
+            } else {
+                List(productService.products) { product in
+                    NavigationLink(destination: ProductDetailView(product: product)) {
+                        ProductRowView(product: product)
+                    }
                 }
+                .refreshable {
+                    await productService.refreshProducts()
+                }
+            }
+        }
+        .navigationTitle("On Store")
+        .task {
+            if productService.products.isEmpty {
+                await productService.loadProducts()
             }
         }
     }


### PR DESCRIPTION
## Summary
- replace the cart tab badge logic with a helper that only applies the badge when the cart has items
- simplify HomeView state handling so SwiftUI can infer the correct view builder types and keep refresh logic on the product list

## Testing
- Not run (SwiftUI build tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_b_68e2f24b24fc832d9aa7a651a357737d