### PR TITLE
Fix AppError handling in ProductService

### DIFF
--- a/Services/ProductService.swift
+++ b/Services/ProductService.swift
@@ -13,7 +13,7 @@ final class ProductService {
     var isLoading: Bool = false
     
     /// Error state for handling failures
-    var error: Error?
+    var error: AppError?
     
     private let sampleProducts: [Product] = [
         Product(name: "Running Shoe",
@@ -81,7 +81,7 @@ final class ProductService {
 
             products = sampleProducts
         } catch {
-            self.error = error as? AppError ?? AppError.unknownError
+            self.error = error as? AppError ?? .unknownError
             ErrorHandler.logError(error, context: "ProductService.loadProducts")
         }
     }


### PR DESCRIPTION
## Summary
- update the ProductService error property to use AppError directly
- default unknown errors to AppError.unknownError when catching failures

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_b_68e2f3d6cf30832da27ab4ea8a134178