### PR TITLE
Fix settings reset crash in profile view

### DIFF
--- a/Views/ProfileView.swift
+++ b/Views/ProfileView.swift
@@ -348,11 +348,13 @@ struct SettingsView: View {
     }
 
     private func resetPreferences() {
-        notificationsEnabled = true
-        promotionalNotificationsEnabled = false
-        selectedLanguage = "English"
-        textScale = 1.0
-        preferredTheme = .system
+        let defaults = UserDefaults.standard
+
+        defaults.set(true, forKey: "settings_notifications_enabled")
+        defaults.set(false, forKey: "settings_promotional_notifications")
+        defaults.set("English", forKey: "settings_language")
+        defaults.set(1.0, forKey: "settings_text_scale")
+        defaults.set(SettingsTheme.system.rawValue, forKey: "settings_preferred_theme")
     }
 }
 


### PR DESCRIPTION
## Summary
- update the settings reset helper to write default values via UserDefaults
- avoid mutating the immutable SwiftUI view struct which caused a crash when resetting

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68e314005460832da7bb140f0ad7b675